### PR TITLE
Use lower case sirupsen

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
   scribelog "github.com/sagar8192/logrus-scribe-hook"
 )
 

--- a/logrus_scribe.go
+++ b/logrus_scribe.go
@@ -6,7 +6,7 @@ import (
     "net"
     "os"
 
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/samuel/go-thrift/examples/scribe"
     "github.com/samuel/go-thrift/thrift"
 )


### PR DESCRIPTION
The sirupsen user was renamed from `Sirupsen` to `sirupsen`. In order to not have conflicts renaming the import path would be awsome.